### PR TITLE
Fix error "No rule to make target `arch/arm/boot/dts/imx6q-marsboard.…

### DIFF
--- a/recipes-kernel/linux/linux-marsboard_3.10.53.bb
+++ b/recipes-kernel/linux/linux-marsboard_3.10.53.bb
@@ -11,7 +11,7 @@ SRC_URI = "git://github.com/boundarydevices/linux-imx6.git;branch=${SRCBRANCH} \
            file://imx6q-marsboard.dts \
 "
 
-do_install_prepend () {
+do_compile_prepend () {
 	cp ${WORKDIR}/imx6q-marsboard.dts \
 	${S}/arch/${ARCH}/boot/dts
 }

--- a/recipes-kernel/linux/linux-marsboard_3.10.53.bb
+++ b/recipes-kernel/linux/linux-marsboard_3.10.53.bb
@@ -16,9 +16,9 @@ do_compile_prepend () {
 	${S}/arch/${ARCH}/boot/dts
 }
 
-LOCALVERSION = "-1.1.0+yocto"
-SRCBRANCH = "boundary-imx_3.10.53_1.1.0_ga-pass3"
-SRCREV = "ebb4458575a43cd94f52f2d370739f411bd094e7"
+LOCALVERSION = "-1.1.1+yocto"
+SRCBRANCH = "boundary-imx_3.10.53_1.1.1_ga"
+SRCREV = "${AUTOREV}"
 DEPENDS += "lzop-native bc-native"
 COMPATIBLE_MACHINE = "(mx6)"
 COMPATIBLE_MACHINE = "(marsboard)"


### PR DESCRIPTION
When compiling error "No rule to make target `arch/arm/boot/dts/imx6q-marsboard.dtb'.  Stop." occurs due to the fact that there is no imx6q-marsboard.dts file in the directory arch/arm/boot/dts/
